### PR TITLE
Add ability to post messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 *.userprefs
 packages/
 tmp/
+.vs/
+.idea/
+TestResult.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: true
 
 language: csharp
@@ -7,13 +8,16 @@ mono:
     - 4.2.4 # default on Fedora 24
 
 install:
-    - sudo pip install behave
+    - sudo apt-get install -y python3 python3-pip
+    - sudo pip3 install behave
+    - cat `which behave`
 
 env:
     - BUILD_CONFIGURATION=Release
     - BUILD_CONFIGURATION=Debug
 
 script:
+    - nuget restore
     - xbuild /p:Configuration=$BUILD_CONFIGURATION SocialNetwork.sln
     - behave
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ PRs/issues welcome.
 
 # Testing
 
+There are features tests, written using [`behave`](http://pythonhosted.org/behave/).  
+Then there are unit tests, I'm using NUnit here.
+
 ## Feature tests
 
 ### Requirements
-* python  
+* python (python3 recommended)
 
-    `pip install behave`
+    `pip3 install behave`
 
 ### Running
     behave

--- a/SocialNetwork.sln
+++ b/SocialNetwork.sln
@@ -1,7 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocialNetworkCLI", "SocialNetworkCLI/SocialNetworkCLI.csproj", "{8DBBBADE-1D65-48C5-BBEF-97A1B6F4C2FE}"
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocialNetworkCLI", "SocialNetworkCLI\SocialNetworkCLI.csproj", "{8DBBBADE-1D65-48C5-BBEF-97A1B6F4C2FE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocialNetworkTests", "SocialNetworkTests\SocialNetworkTests.csproj", "{8EDF4429-251A-416D-BB68-93F227191BCF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,5 +17,12 @@ Global
 		{8DBBBADE-1D65-48C5-BBEF-97A1B6F4C2FE}.Debug|x86.Build.0 = Debug|x86
 		{8DBBBADE-1D65-48C5-BBEF-97A1B6F4C2FE}.Release|x86.ActiveCfg = Release|x86
 		{8DBBBADE-1D65-48C5-BBEF-97A1B6F4C2FE}.Release|x86.Build.0 = Release|x86
+		{8EDF4429-251A-416D-BB68-93F227191BCF}.Debug|x86.ActiveCfg = Debug|x86
+		{8EDF4429-251A-416D-BB68-93F227191BCF}.Debug|x86.Build.0 = Debug|x86
+		{8EDF4429-251A-416D-BB68-93F227191BCF}.Release|x86.ActiveCfg = Release|x86
+		{8EDF4429-251A-416D-BB68-93F227191BCF}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/SocialNetworkCLI/MainLoop.cs
+++ b/SocialNetworkCLI/MainLoop.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI
+{
+    public class MainLoop
+    {
+        private TextReader _inputReader;
+
+        public MainLoop(TextReader inputReader, TextWriter outputWriter)
+        {
+            _inputReader = inputReader;
+        }
+
+        public void Loop()
+        {
+            var lastLine = string.Empty;
+            do
+            {
+                lastLine = _inputReader.ReadLine();
+                if(!string.IsNullOrWhiteSpace(lastLine))
+                {
+                    lastLine = lastLine.Trim().ToLower();   
+                }
+            } while (lastLine != "exit" && lastLine != "quit");
+        }
+    }
+}

--- a/SocialNetworkCLI/Program.cs
+++ b/SocialNetworkCLI/Program.cs
@@ -6,7 +6,8 @@ namespace SocialNetworkCLI
 	{
 		public static int Main (string[] args)
 		{
-			Console.In.ReadLine();
+			var looper = new MainLoop(Console.In, Console.Out);
+            looper.Loop();
 			return 0;
 		}
 	}

--- a/SocialNetworkCLI/SocialNetworkCLI.csproj
+++ b/SocialNetworkCLI/SocialNetworkCLI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -14,7 +14,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
@@ -30,11 +30,13 @@
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
     <LangVersion>6</LangVersion>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MainLoop.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SocialNetworkTests/MainLoopTests.cs
+++ b/SocialNetworkTests/MainLoopTests.cs
@@ -1,0 +1,112 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    [Timeout(1 * 5000)]
+    public class MainLoopTests
+    {
+        [Test]
+        public void ShouldNot_ConsumeAnythingFromTheInput_IfNotStarted()
+        {
+            // Arrange
+            var inputReader = new Mock<TextReader>();
+            var outputWriter = new Mock<TextWriter>();
+            var looper = new MainLoop(inputReader.Object, outputWriter.Object);
+            
+            // Assert
+            inputReader.Verify( reader => reader.Read(), Times.Never );
+        }
+
+        [Test]
+        public void ShouldNot_WriteAnythingToTheOutput_IfNotStarted()
+        {
+            // Arrange
+            var inputReader = new Mock<TextReader>();
+            var outputWriter = new Mock<TextWriter>();
+            var looper = new MainLoop(inputReader.Object, outputWriter.Object);
+
+            // Assert
+            outputWriter.Verify(writer => writer.Write(It.IsAny<string>()), Times.Never);
+        }
+
+        [Test]
+        public void Should_Exit_AfterConsumingSingleExitLine()
+        {
+            // Arrange
+            var rawInputReader = new StringReader("exit" + Environment.NewLine);
+            var outputWriter = new Mock<TextWriter>();
+            var looper = new MainLoop(rawInputReader, outputWriter.Object);
+
+            // Act
+            looper.Loop();
+
+            // Assert 
+            // We just want no timeout triggered here
+        }
+
+        [Test]
+        public void Should_Exit_AfterConsumingSingleQuitLine()
+        {
+            // Arrange
+            var rawInputReader = new StringReader("quit" + Environment.NewLine);
+            var outputWriter = new Mock<TextWriter>();
+            var looper = new MainLoop(rawInputReader, outputWriter.Object);
+
+            // Act
+            looper.Loop();
+
+            // Assert 
+            // We just want no timeout triggered here
+        }
+
+        [Test]
+        public void Should_Exit_AfterConsumingSingleExitLineCasedStrangely()
+        {
+            // Arrange
+            var rawInputReader = new StringReader("eXiT" + Environment.NewLine);
+            var outputWriter = new Mock<TextWriter>();
+            var looper = new MainLoop(rawInputReader, outputWriter.Object);
+
+            // Act
+            looper.Loop();
+
+            // Assert 
+            // We just want no timeout triggered here
+        }
+
+        [Test]
+        public void Should_ConsumeAllInput_BeforeExiting()
+        {
+            // Arrange
+            var inputBuilder = new StringBuilder();
+            inputBuilder.AppendLine("a");
+            inputBuilder.AppendLine("b");
+            inputBuilder.AppendLine("c");
+            inputBuilder.AppendLine("exit");
+
+            var inputBytes = Encoding.UTF8.GetBytes(inputBuilder.ToString());
+            var inputStream = new MemoryStream(inputBytes);
+            var rawInputReader = new StreamReader(inputStream);
+            var outputWriter = new Mock<TextWriter>();
+            var looper = new MainLoop(rawInputReader, outputWriter.Object);
+
+            // Act
+            looper.Loop();
+
+            // Assert 
+            Assert.IsTrue(inputStream.Position > 0);
+            Assert.AreEqual(inputStream.Length, inputStream.Position);
+        }
+
+    }
+}

--- a/SocialNetworkTests/Properties/AssemblyInfo.cs
+++ b/SocialNetworkTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SocialNetworkTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("nunit.tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SocialNetworkTests/SocialNetworkTests.csproj
+++ b/SocialNetworkTests/SocialNetworkTests.csproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8EDF4429-251A-416D-BB68-93F227191BCF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SocialNetworkTests</RootNamespace>
+    <AssemblyName>SocialNetworkTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainLoopTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SocialNetworkCLI\SocialNetworkCLI.csproj">
+      <Project>{8DBBBADE-1D65-48C5-BBEF-97A1B6F4C2FE}</Project>
+      <Name>SocialNetworkCLI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SocialNetworkTests/packages.config
+++ b/SocialNetworkTests/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Moq" version="4.5.21" targetFramework="net45" />
+  <package id="NUnit" version="3.4.1" targetFramework="net45" />
+  <package id="NUnit.Console" version="3.4.1" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.4.1" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.4.1" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.4.1" targetFramework="net45" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.4.1" targetFramework="net45" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.1" targetFramework="net45" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.4.1" targetFramework="net45" />
+</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,9 @@ build:
 install:
     - set PATH=C:\Python35-x64\;%PATH%
     - set PATH=C:\Python35-x64\scripts;%PATH%
-    - pip install behave
+    - pip3 install behave
+    - nuget restore
 
 test_script:
+    - packages\NUnit.ConsoleRunner.3.4.1\tools\nunit3-console.exe SocialNetworkTests\bin\x86\%CONFIGURATION%\SocialNetworkTests.dll
     - behave

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,22 @@
+import subprocess
+import os
+import platform
+from behave import *
+
+def get_returncode(context):
+    context.process.poll()
+    return context.process.returncode
+
+def before_scenario(context, scenario):
+    build_configuration = os.environ.get('BUILD_CONFIGURATION') or os.environ.get('CONFIGURATION') or "Release"
+    path = "SocialNetworkCLI/bin/%s/SocialNetworkCLI.exe" % build_configuration
+    launchers = {"Windows": (path, []), "Linux": ("mono", path)}
+    (launcher, arguments) = launchers[platform.system()]
+    context.process = subprocess.Popen(args = [launcher, arguments], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+def after_scenario(context, scenario):
+    if get_returncode(context) == None:
+        exit_text = "quit%s" % os.linesep
+        (output,_) = context.process.communicate(bytearray(exit_text, 'utf-8'), timeout = 5)
+    if get_returncode(context) == None:
+        context.process.kill()

--- a/features/exiting.feature
+++ b/features/exiting.feature
@@ -1,6 +1,0 @@
-Feature: Exiting the Social Network commandline client
-
-	Scenario: exiting right after launch
-		When I launch the client
-		And I type "exit"
-		Then the client should quit 

--- a/features/interactivity.feature
+++ b/features/interactivity.feature
@@ -1,6 +1,5 @@
 Feature: The Social Network commandline client should be interactive
 
     Scenario: waiting for user input after launch
-		When I launch the client
-		And I wait for 1 second
-		Then the client should still be there
+		When I wait for 1 second
+		Then the prompt should still be there

--- a/features/posting.feature
+++ b/features/posting.feature
@@ -1,0 +1,18 @@
+Feature: Posting messages
+
+    Anyone at the terminal should be able to post a message to their timeline.
+
+    Scenario: Posting first message
+        When I type "Alice -> I love the weather today"
+        Then the prompt should still be there
+
+    Scenario: Two users posting one after another
+        When I type "Alice -> I love the weather today"
+        And I pass the keyboard to another person
+        And they type "Bob -> Damn! We lost!"
+        Then the prompt should still be there
+
+    Scenario: Posting subsequent messages
+        Given I've already posted as Alice
+        When I type "Alice -> I love the weather today"
+        Then the prompt should still be there

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -1,31 +1,25 @@
 import time
-import subprocess
 import os
-import platform
 
-@when(u'I launch the client')
-def step_impl(context):
-    build_configuration = os.environ.get('BUILD_CONFIGURATION') or os.environ.get('CONFIGURATION') or "Release"
-    path = "SocialNetworkCLI/bin/%s/SocialNetworkCLI.exe" % build_configuration
-    launchers = {"Windows": (path, []), "Linux": ("mono", path)}
-    (launcher, arguments) = launchers[platform.system()]
-    context.process = subprocess.Popen(args = [launcher, arguments], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+@when(u'I type "{text}"')
+@when(u'They type "{text}"')
+def step_impl(context, text):
+    text_to_write = text + os.linesep
+    context.process.stdin.write(bytearray(text_to_write, 'utf-8'))
 
-@when(u'I type "exit"')
+@then(u'the prompt should still be there')
 def step_impl(context):
-    context.process.communicate(b"exit\n")
-
-@then(u'the client should quit')
-def step_impl(context):
-    assert get_returncode(context) != None
-
-@then(u'the client should still be there')
-def step_impl(context):
-    assert get_returncode(context) == None
+    return_code = get_returncode(context)
+    assert return_code == None
 
 @when(u'I wait for 1 second')
 def step_impl(context):
     time.sleep(1)
+
+@when(u'I pass the keyboard to another person')
+# this is an interaction between people, not necessarily concerning the application itself 
+def step_impl(context):
+    pass
 
 def get_returncode(context):
     context.process.poll()

--- a/features/steps/posting_steps.py
+++ b/features/steps/posting_steps.py
@@ -1,0 +1,4 @@
+@given(u'I\'ve already posted as Alice')
+def step_impl(context):
+    context.execute_steps(u"""When I type "Alice -> Some previous text by Alice" """)
+


### PR DESCRIPTION
Fun fact. Posting so far is just swallowing messages over and over
again. There is no way to check if the message has been posted yet -
please expect changes when implementing the `reading` feature.

Resigned from the explicit feature test for exiting the application -
had some problems driving it properly from `behave` and wanted to move
on. The test now exists in the unit test space.

Speaking of unit tests - there are some now - Travis and AppVeyor runs
include them as well.

Settled on Python3, as it has better support for timeouts during
communication with subprocesses.

Standardized on x86 for all projects - no need for > 2/4 GB memory and
avoiding all multiplatform/processor issues here.
