### PR TITLE
Add ability to read posted user messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,20 @@ PRs/issues welcome.
 [![Build Status](https://travis-ci.org/cyplo/social_network.svg?branch=master)](https://travis-ci.org/cyplo/social_network)
 [![Build status](https://ci.appveyor.com/api/projects/status/s73wngt2k6bcf58v/branch/master?svg=true)](https://ci.appveyor.com/project/cyplo/social-network/branch/master)
 
+
 ## Requirements
 
 * Mono 4.2 / .Net framework 4.5
+
+## Building on Linux
+
+    nuget restore
+    xbuild /p:Configuration=Releas
+
+## Building on Windows
+
+    nuget restore
+    msbuild /p:Configuration=Release
 
 # Testing
 
@@ -21,12 +32,21 @@ Then there are unit tests, I'm using NUnit here.
 ## Feature tests
 
 ### Requirements
-* python (python3 recommended)
+* python3
 
     `pip3 install behave`
 
-### Running
+### Running feature tests
+
     behave
+
+### Running unit tests under Linux
+
+    mono ./packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe SocialNetworkTests/bin/x86/Release/SocialNetworkTests.dll
+
+### Running unit tests under Windows
+
+     packages\NUnit.ConsoleRunner.3.4.1\tools\nunit3-console.exe SocialNetworkTests\bin\x86\Release\SocialNetworkTests.dll
 
 ### A note on the choice of the feature testing framework
 I knew I needed some testing framework that would allow me to write high level tests and launch the final executable against them. This would allow me to mimic the interaction the user has with the binary without skipping layers and calling the C# code directly.

--- a/SocialNetworkCLI/Commands/CommandExtractor.cs
+++ b/SocialNetworkCLI/Commands/CommandExtractor.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI
+{
+    public class CommandExtractor : ICommandExtractor
+    {
+        private readonly ITimelineRepository _timelineRepository;
+        private readonly IList<ICommandFactory> _availableCommandFactories;
+        private readonly ICommandFactory _defaultCommandFactory;
+
+        public CommandExtractor(ITimelineRepository timelineRepository, IList<ICommandFactory> availableCommandFactories, ICommandFactory defaultCommandFactory){
+            _timelineRepository = timelineRepository;
+            _availableCommandFactories = availableCommandFactories;
+            _defaultCommandFactory = defaultCommandFactory;
+        }
+
+        public ICommand Extract(string line)
+        {
+            var matchingFactories = from commandFactory in _availableCommandFactories
+                where line.Contains(commandFactory.GetCommandVerb())
+                select commandFactory;
+
+            var factory = _defaultCommandFactory;
+            var lineParts = new[] { line };
+            if (matchingFactories.Any())
+            {
+                factory = matchingFactories.First();
+                lineParts = line.Split(new[] { factory.GetCommandVerb() }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            var username = lineParts[0].Trim();
+            var argument = string.Empty;
+            if (lineParts.Length > 1)
+            {
+                argument = lineParts[1].Trim();
+            }
+
+            return factory.GetCommand(_timelineRepository, username, argument);
+        }
+    }
+}

--- a/SocialNetworkCLI/Commands/ICommand.cs
+++ b/SocialNetworkCLI/Commands/ICommand.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI
+{
+    public interface ICommandFactory
+    {
+        string GetCommandVerb();
+        ICommand GetCommand(ITimelineRepository timelineRepository, string username, string argument=null);
+    }
+
+    public interface ICommand
+    {
+        ITimelineRepository TimelineRepository { get; }
+        string Username { get; }
+        string Argument { get; }
+        string Execute();
+    }
+}

--- a/SocialNetworkCLI/Commands/ICommandExtractor.cs
+++ b/SocialNetworkCLI/Commands/ICommandExtractor.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI
+{
+    public interface ICommandExtractor
+    {
+        ICommand Extract(string line);
+    }
+}

--- a/SocialNetworkCLI/Commands/posting/PostingCommand.cs
+++ b/SocialNetworkCLI/Commands/posting/PostingCommand.cs
@@ -1,0 +1,22 @@
+﻿namespace SocialNetworkCLI.Commands.Posting
+{
+    public class PostingCommand : ICommand
+    {
+        public ITimelineRepository TimelineRepository { get; }
+        public string Username { get; }
+        public string Argument { get; }
+
+        public PostingCommand(ITimelineRepository timelineRepository, string username, string message)
+        {
+            Username = username;
+            Argument = message;
+            TimelineRepository = timelineRepository;
+        }
+
+        public string Execute()
+        {
+            TimelineRepository.Post(Username, Argument);
+            return null;
+        }
+    }
+}

--- a/SocialNetworkCLI/Commands/posting/PostingCommandFactory.cs
+++ b/SocialNetworkCLI/Commands/posting/PostingCommandFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI.Commands.Posting
+{
+    public class PostingCommandFactory : ICommandFactory
+    {
+        public string GetCommandVerb()
+        {
+            return "->";
+        }
+
+        public ICommand GetCommand(ITimelineRepository timelineRepository, string username, string argument = null)
+        {
+            return new PostingCommand(timelineRepository, username, argument);
+        }
+    }
+}

--- a/SocialNetworkCLI/Commands/reading/ReadingCommand.cs
+++ b/SocialNetworkCLI/Commands/reading/ReadingCommand.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+
+namespace SocialNetworkCLI.Commands.Reading
+{
+    public class ReadingCommand : ICommand
+    {
+        public ITimelineRepository TimelineRepository { get; }
+        public string Username { get; }
+        public string Argument { get; }
+
+        public ReadingCommand(ITimelineRepository timelineRepository, string username)
+        {
+            TimelineRepository = timelineRepository;
+            Username = username;
+            Argument = null;
+        }
+
+
+        public string Execute()
+        {
+            var allMessages = TimelineRepository.Read(Username).OrderByDescending( message => message.Timestamp );
+            if (!allMessages.Any())
+            {
+                return null;
+            }
+
+            var resultTexts = from message in allMessages
+                              select message.Text + " (" + FormatTime(message.Timestamp) + ")";
+            var resultText = string.Join(Environment.NewLine, resultTexts);
+            return resultText;
+        }
+
+        // TODO: probably worth extracting the time formatter part to a separate class
+        // TODO: look into using libraries that might do the time => text transformation for us (Humanizer maybe ?)
+        private string FormatTime(DateTime timestamp)
+        {
+            var messageAge = DateTime.Now - timestamp;
+            var ageInMinutes = messageAge.TotalMinutes;
+            if (ageInMinutes < 1)
+            {
+                return "just now";
+            }
+
+            if (ageInMinutes >= 1 && ageInMinutes < 2)
+            {
+                return "1 minute ago";
+            }
+
+            return Math.Floor(ageInMinutes) + " minutes ago";
+        }
+    }
+}

--- a/SocialNetworkCLI/Commands/reading/ReadingCommandFactory.cs
+++ b/SocialNetworkCLI/Commands/reading/ReadingCommandFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI.Commands.Reading
+{
+    public class ReadingCommandFactory : ICommandFactory
+    {
+        public string GetCommandVerb()
+        {
+            return null;
+        }
+
+        public ICommand GetCommand(ITimelineRepository timelineRepository, string username, string argument = null)
+        {
+            return new ReadingCommand(timelineRepository, username);
+        }
+    }
+}

--- a/SocialNetworkCLI/MainLoop.cs
+++ b/SocialNetworkCLI/MainLoop.cs
@@ -9,24 +9,45 @@ namespace SocialNetworkCLI
 {
     public class MainLoop
     {
-        private TextReader _inputReader;
+        private readonly TextReader _inputReader;
+        private readonly ICommandExtractor _commandExtractor;
+        private readonly TextWriter _outputWriter;
 
-        public MainLoop(TextReader inputReader, TextWriter outputWriter)
+        public MainLoop(TextReader inputReader, TextWriter outputWriter, ICommandExtractor commandExtractor)
         {
             _inputReader = inputReader;
+            _outputWriter = outputWriter;
+            _commandExtractor = commandExtractor;
         }
 
         public void Loop()
         {
-            var lastLine = string.Empty;
+            var line = string.Empty;
             do
             {
-                lastLine = _inputReader.ReadLine();
-                if(!string.IsNullOrWhiteSpace(lastLine))
+                line = _inputReader.ReadLine();
+                if (string.IsNullOrWhiteSpace(line))
                 {
-                    lastLine = lastLine.Trim().ToLower();   
+                    continue;
                 }
-            } while (lastLine != "exit" && lastLine != "quit");
+
+                line = line.Trim();
+                if (line.ToLower() == "exit" || line.ToLower() == "quit")
+                {
+                    break;
+                }
+
+                var command = _commandExtractor.Extract(line);
+                var result = command.Execute();
+                if (string.IsNullOrWhiteSpace(result))
+                {
+                    continue;
+                }
+
+                _outputWriter.Write(result + Environment.NewLine);
+                _outputWriter.Flush();
+
+            } while (true);
         }
     }
 }

--- a/SocialNetworkCLI/Message.cs
+++ b/SocialNetworkCLI/Message.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI
+{
+    public class Message
+    {
+        public string Text { get; }
+        public DateTime Timestamp { get; }
+
+        public Message(string text, DateTime timestamp)
+        {
+            Text = text;
+            Timestamp = timestamp;
+        }
+    }
+}

--- a/SocialNetworkCLI/Program.cs
+++ b/SocialNetworkCLI/Program.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Remoting.Messaging;
+using SocialNetworkCLI.Commands.Posting;
+using SocialNetworkCLI.Commands.Reading;
+using SocialNetworkCLI.Repositories;
 
 namespace SocialNetworkCLI
 {
@@ -6,9 +11,16 @@ namespace SocialNetworkCLI
 	{
 		public static int Main (string[] args)
 		{
-			var looper = new MainLoop(Console.In, Console.Out);
+            var availableCommandFactories = new List<ICommandFactory>() {new PostingCommandFactory()};
+            var defaultCommandFactory = new ReadingCommandFactory();
+		    ICommandExtractor commandExtractor = new CommandExtractor(new TimelineRepository(), availableCommandFactories, defaultCommandFactory);
+			var looper = new MainLoop(Console.In, Console.Out, commandExtractor);
             looper.Loop();
-			return 0;
+
+            Console.Out.Flush();
+            return 0;
 		}
 	}
+
+    
 }

--- a/SocialNetworkCLI/Repositories/ITimelineRepository.cs
+++ b/SocialNetworkCLI/Repositories/ITimelineRepository.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI
+{
+    public interface ITimelineRepository
+    {
+        void Post(string username, string message);
+        IEnumerable<Message> Read(string username);
+    }
+}

--- a/SocialNetworkCLI/Repositories/TimelineRepository.cs
+++ b/SocialNetworkCLI/Repositories/TimelineRepository.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SocialNetworkCLI.Repositories
+{
+    public class TimelineRepository : ITimelineRepository
+    {
+        // user => message list
+        private readonly Dictionary<string, List<Message>> _timelines = new Dictionary<string, List<Message>>();
+
+        public void Post(string username, string message)
+        {
+            // TODO: evaluate using CuttingEdge for the project
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                throw new ArgumentException("Cannot post with empty username");
+            }
+
+            var timelineToChange = new List<Message>();
+            if (_timelines.ContainsKey(username))
+            {
+                timelineToChange = _timelines[username];
+            }
+            timelineToChange.Add(new Message(message, DateTime.Now));
+            _timelines[username] = timelineToChange;
+        }
+
+        public IEnumerable<Message> Read(string username)
+        {
+            if (_timelines.ContainsKey(username))
+            {
+                return _timelines[username];
+            }
+            return new List<Message>();
+        }
+    }
+}

--- a/SocialNetworkCLI/SocialNetworkCLI.csproj
+++ b/SocialNetworkCLI/SocialNetworkCLI.csproj
@@ -36,9 +36,19 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\CommandExtractor.cs" />
+    <Compile Include="Commands\ICommand.cs" />
+    <Compile Include="Commands\ICommandExtractor.cs" />
+    <Compile Include="Commands\posting\PostingCommandFactory.cs" />
+    <Compile Include="Commands\reading\ReadingCommandFactory.cs" />
+    <Compile Include="Repositories\ITimelineRepository.cs" />
     <Compile Include="MainLoop.cs" />
+    <Compile Include="Message.cs" />
+    <Compile Include="Commands\posting\PostingCommand.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Commands\reading\ReadingCommand.cs" />
+    <Compile Include="Repositories\TimelineRepository.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/SocialNetworkTests/CommandExtractorTests.cs
+++ b/SocialNetworkTests/CommandExtractorTests.cs
@@ -1,0 +1,163 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class CommandExtractorTests
+    {
+        [Test]
+        public void Should_ExtractDefaultCommand_GivenEmptyCommandFactoryList()
+        {
+            // Arrange
+            var defaultCommandFactoryMock = new Mock<ICommandFactory>();
+            var defaultCommandMock = new Mock<ICommand>();
+            defaultCommandFactoryMock.Setup(
+                commandFactory =>
+                    commandFactory.GetCommand(It.IsAny<ITimelineRepository>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(defaultCommandMock.Object);
+            var extractor = new CommandExtractor(null, new List<ICommandFactory>(), defaultCommandFactoryMock.Object);
+
+            // Act
+            var command = extractor.Extract("some line");
+
+            // Assert
+            Assert.NotNull(command);
+            Assert.AreSame(defaultCommandMock.Object, command);
+        }
+
+        [Test]
+        public void Should_PassCorrectUsername_GivenEmptyCommandFactoryList()
+        {
+            // Arrange
+            var defaultCommandFactoryMock = new Mock<ICommandFactory>();
+            var defaultCommand = new Mock<ICommand>();
+            defaultCommandFactoryMock.Setup(
+                commandFactory =>
+                    commandFactory.GetCommand(It.IsAny<ITimelineRepository>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(defaultCommand.Object);
+            var extractor = new CommandExtractor(null, new List<ICommandFactory>(), defaultCommandFactoryMock.Object);
+
+            var username = "some user";
+            var line = username;
+
+            // Act
+            extractor.Extract(line);
+
+            // Assert
+            defaultCommandFactoryMock.Verify( commandFactory => commandFactory.GetCommand(It.IsAny<ITimelineRepository>(), username, It.IsAny<string>()) );
+        }
+
+        [Test]
+        public void Should_ExtractCommand_ForTheMatchingVerb()
+        {
+            // Arrange
+            var factory = new SomeCommandFactory();
+            var factories = new List<ICommandFactory>() { factory };
+            var extractor = new CommandExtractor(null, factories, null);
+            var line = "Some user " + factory.GetCommandVerb() + " some data";
+
+            // Act
+            var command = extractor.Extract(line);
+
+            // Assert
+            Assert.IsNotNull(command);
+            Assert.IsInstanceOf<SomeCommand>(command);
+        }
+
+        [Test]
+        public void Should_PassTheUsernameToTheExtractedCommand()
+        {
+            // Arrange
+            var factory = new SomeCommandFactory();
+            var factories = new List<ICommandFactory>() { factory };
+            var extractor = new CommandExtractor(null, factories, null);
+            var username = "Some user";
+            var line = username + " " + factory.GetCommandVerb() + " some data";
+
+            // Act
+            var command = extractor.Extract(line);
+
+            // Assert
+            var someCommand = command as SomeCommand;
+            Assert.AreEqual(username, someCommand.Username);
+        }
+
+        [Test]
+        public void Should_PassTheCommandArgumentToTheExtractedCommand()
+        {
+            // Arrange
+            var factory = new SomeCommandFactory();
+            var factories = new List<ICommandFactory>() { factory };
+            var extractor = new CommandExtractor(null, factories, null);
+            var username = "Some user";
+            var commandArgument = "some data";
+            var line = username + " " + factory.GetCommandVerb() + " " + commandArgument;
+
+            // Act
+            var command = extractor.Extract(line);
+
+            // Assert
+            var someCommand = command as SomeCommand;
+            Assert.AreEqual(commandArgument, someCommand.Argument);
+        }
+
+        [Test]
+        public void Should_PassTimelineRepositoryTheExtractedCommand()
+        {
+            // Arrange
+            var factory = new SomeCommandFactory();
+            var factories = new List<ICommandFactory>() { factory };
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var extractor = new CommandExtractor(timelineRepositoryMock.Object, factories, null);
+            var username = "Some user";
+            var commandArgument = "some data";
+            var line = username + " " + factory.GetCommandVerb() + " " + commandArgument;
+
+            // Act
+            var command = extractor.Extract(line);
+
+            // Assert
+            var someCommand = command as SomeCommand;
+            Assert.AreEqual(timelineRepositoryMock.Object, someCommand.TimelineRepository);
+        }
+
+        private class SomeCommandFactory : ICommandFactory
+        {
+            public string GetCommandVerb()
+            {
+                return "COMMAND";
+            }
+
+            public ICommand GetCommand(ITimelineRepository timelineRepository, string username, string argument = null)
+            {
+                return new SomeCommand(timelineRepository, username, argument);
+            }
+        }
+
+        private class SomeCommand : ICommand
+        {
+            public ITimelineRepository TimelineRepository { get; set; }
+            public string Username { get; private set; }
+            public string Argument { get; private set; }
+
+            public SomeCommand(ITimelineRepository timelineRepository, string username, string argument)
+            {
+                Username = username;
+                Argument = argument;
+                TimelineRepository = timelineRepository;
+            }
+
+            public string Execute()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/SocialNetworkTests/MainLoopCommandExecutionTests.cs
+++ b/SocialNetworkTests/MainLoopCommandExecutionTests.cs
@@ -1,0 +1,55 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class MainLoopCommandExecutionTests
+    {
+        [Test]
+        public void Should_ExecuteCommandGivenByTheExtractor()
+        {
+            // Arrange
+            var inputBuilder = new StringBuilder();
+            inputBuilder.AppendLine("some command");
+            inputBuilder.AppendLine("exit");
+
+            var inputBytes = Encoding.UTF8.GetBytes(inputBuilder.ToString());
+            var inputStream = new MemoryStream(inputBytes);
+            var rawInputReader = new StreamReader(inputStream);
+            var outputWriter = new StringWriter();
+            var commandMock = new Mock<ICommand>();
+            var commandExtractor = new AlwaysSomeCommandExtractor(commandMock.Object);
+
+            var looper = new MainLoop(rawInputReader, outputWriter, commandExtractor);
+
+            // Act
+            looper.Loop();
+
+            // Assert 
+            commandMock.Verify( command => command.Execute(), Times.Once );
+        }
+
+        private class AlwaysSomeCommandExtractor : ICommandExtractor
+        {
+            private readonly ICommand _commandToReturn;
+
+            public AlwaysSomeCommandExtractor(ICommand commandToReturn)
+            {
+                _commandToReturn = commandToReturn;
+            }
+
+            public ICommand Extract(string line)
+            {
+                return _commandToReturn;
+            }
+        }
+    }
+}

--- a/SocialNetworkTests/PostingCommandFactoryTests.cs
+++ b/SocialNetworkTests/PostingCommandFactoryTests.cs
@@ -1,0 +1,68 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+using SocialNetworkCLI.Commands.Posting;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class PostingCommandFactoryTests
+    {
+        [Test]
+        public void Should_HaveTheCorrectVerbAssigned()
+        {
+            // Act
+            var commandFactory = new PostingCommandFactory();
+            
+            // Assert
+            Assert.AreEqual("->", commandFactory.GetCommandVerb());
+        }
+
+        [Test]
+        public void Should_PassOnTheTimelineRepository()
+        {
+            // Arrange
+            var commandFactory = new PostingCommandFactory();
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+
+            // Act
+            var command = commandFactory.GetCommand(timelineRepositoryMock.Object, null);
+
+            // Assert
+            Assert.AreEqual(timelineRepositoryMock.Object, command.TimelineRepository);
+        }
+
+        [Test]
+        public void Should_PassOnTheUsername()
+        {
+            // Arrange
+            var commandFactory = new PostingCommandFactory();
+            var username = "some username";
+
+            // Act
+            var command = commandFactory.GetCommand(null, username);
+
+            // Assert
+            Assert.AreEqual(username, command.Username);
+        }
+
+        [Test]
+        public void Should_PassOnTheCommadArgument()
+        {
+            // Arrange
+            var commandFactory = new PostingCommandFactory();
+            var commandArgument = "some argument";
+
+            // Act
+            var command = commandFactory.GetCommand(null, null, commandArgument);
+
+            // Assert
+            Assert.AreEqual(commandArgument, command.Argument);
+        }
+    }
+}

--- a/SocialNetworkTests/PostingCommandTests.cs
+++ b/SocialNetworkTests/PostingCommandTests.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+using SocialNetworkCLI.Commands.Posting;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class PostingCommandTests
+    {
+        [Test]
+        public void Executing_Should_PostToUserTimeline()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+
+            var username = "Alice";
+            var message = "I love the weather today";
+            var command = new PostingCommand(timelineRepositoryMock.Object, username, message);
+
+            // Act
+            command.Execute();
+
+            // Assert
+            timelineRepositoryMock.Verify( repository => repository.Post(username, message), Times.Once );
+        }
+    }
+}

--- a/SocialNetworkTests/ReadingCommandFactoryTests.cs
+++ b/SocialNetworkTests/ReadingCommandFactoryTests.cs
@@ -1,0 +1,55 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+using SocialNetworkCLI.Commands.Posting;
+using SocialNetworkCLI.Commands.Reading;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class ReadingCommandFactoryTests
+    {
+        [Test]
+        public void Should_HaveNoVerbAssigned()
+        {
+            // Act
+            var commandFactory = new ReadingCommandFactory();
+
+            // Assert
+            Assert.IsNull(commandFactory.GetCommandVerb());
+        }
+
+        [Test]
+        public void Should_PassOnTheTimelineRepository()
+        {
+            // Arrange
+            var commandFactory = new ReadingCommandFactory();
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+
+            // Act
+            var command = commandFactory.GetCommand(timelineRepositoryMock.Object, null);
+
+            // Assert
+            Assert.AreEqual(timelineRepositoryMock.Object, command.TimelineRepository);
+        }
+
+        [Test]
+        public void Should_PassOnTheUsername()
+        {
+            // Arrange
+            var commandFactory = new ReadingCommandFactory();
+            var username = "some username";
+
+            // Act
+            var command = commandFactory.GetCommand(null, username);
+
+            // Assert
+            Assert.AreEqual(username, command.Username);
+        }
+    }
+}

--- a/SocialNetworkTests/ReadingCommandTest.cs
+++ b/SocialNetworkTests/ReadingCommandTest.cs
@@ -1,0 +1,221 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using SocialNetworkCLI;
+using SocialNetworkCLI.Commands.Reading;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class ReadingCommandTest
+    {
+        [Test]
+        public void Should_ReturnEmptyResponse_GivenNoMessagesForTheUser()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var response = command.Execute();
+
+            // Assert
+            Assert.IsNull(response);
+        }
+
+        [Test]
+        public void Should_AskTimelineRepositoryForInformationForTheRightUser()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            command.Execute();
+
+            // Assert
+            timelineRepositoryMock.Verify( repository => repository.Read(username), Times.Once );
+        }
+
+        [Test]
+        public void Should_ReturnTheSoleMessage_GivenOneMessageInRepository()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText = "Some message";
+            var timestamp = DateTime.Now;
+            var message = new Message(messageText, timestamp);
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(new List<Message>() {message});
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsTrue( result.StartsWith(messageText) );
+        }
+
+        [Test]
+        public void Should_MarkTheMessageJustNow_GivenMessagePostedLessThanMinuteAgo()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText = "Some message";
+            var timestamp = DateTime.Now;
+            var message = new Message(messageText, timestamp);
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(new List<Message>() { message });
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.EndsWith("(just now)"));
+        }
+
+        [Test]
+        public void Should_MarkTheMessageWithAgeInMinutes_GivenMessagePostedAMinuteAgo()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText = "Some message";
+            var timestamp = DateTime.Now - TimeSpan.FromSeconds(61);
+            var message = new Message(messageText, timestamp);
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(new List<Message>() { message });
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.EndsWith("(1 minute ago)"));
+        }
+
+        [Test]
+        public void Should_MarkTheMessageWithAgeInMinutes_GivenMessagePosted3MinutesAgo()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText = "Some message";
+            var timestamp = DateTime.Now - TimeSpan.FromSeconds(3 * 60 + 1);
+            var message = new Message(messageText, timestamp);
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(new List<Message>() { message });
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.EndsWith("(3 minutes ago)"));
+        }
+
+        [Test]
+        public void Should_ReturnNumberOfLinesEqualToNumberOfMessages()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText1 = "Some message 1";
+            var messageText2 = "Some message 2";
+            var messageText3 = "Some message 3";
+            var timestamp = DateTime.Now;
+
+            var message1 = new Message(messageText1, timestamp);
+            var message2 = new Message(messageText2, timestamp);
+            var message3 = new Message(messageText3, timestamp);
+            var messages = new List<Message>() {message1, message2, message3};
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(messages);
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            var lines = result.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+            Assert.AreEqual(3, lines.Length);
+        }
+
+        [Test]
+        public void Should_ReturnAllMessages()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText1 = "Some message 1";
+            var messageText2 = "Some message 2";
+            var messageText3 = "Some message 3";
+            var timestamp = DateTime.Now;
+
+            var message1 = new Message(messageText1, timestamp);
+            var message2 = new Message(messageText2, timestamp);
+            var message3 = new Message(messageText3, timestamp);
+            var messages = new List<Message>() {message1, message2, message3};
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(messages);
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            Assert.True(result.Contains(messageText1));
+            Assert.True(result.Contains(messageText2));
+            Assert.True(result.Contains(messageText3));
+        }
+
+        [Test]
+        public void Should_ReturnMessagesInReverseChronologicalOrder()
+        {
+            // Arrange
+            var timelineRepositoryMock = new Mock<ITimelineRepository>();
+            var username = "Alice";
+            var messageText1 = "Some message 1 - this should be first";
+            var messageText2 = "Some message 2 - this should be last";
+            var messageText3 = "Some message 3 - this should be the middle one";
+            var timestamp = DateTime.Now - TimeSpan.FromHours(1);
+
+            var message1 = new Message(messageText1, timestamp + TimeSpan.FromMinutes(1) ); // later
+            var message2 = new Message(messageText2, timestamp - TimeSpan.FromMinutes(1) ); // earlier
+            var message3 = new Message(messageText3, timestamp );
+            var messages = new List<Message>() { message1, message2, message3 };
+            timelineRepositoryMock.Setup(repository => repository.Read(username))
+                .Returns(messages);
+
+            var command = new ReadingCommand(timelineRepositoryMock.Object, username);
+
+            // Act
+            var result = command.Execute();
+
+            // Assert
+            var lines = result.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            Assert.True(lines[0].StartsWith(messageText1));
+            Assert.True(lines[1].StartsWith(messageText3));
+            Assert.True(lines[2].StartsWith(messageText2));
+        }
+    }
+}

--- a/SocialNetworkTests/SocialNetworkTests.csproj
+++ b/SocialNetworkTests/SocialNetworkTests.csproj
@@ -67,8 +67,15 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandExtractorTests.cs" />
+    <Compile Include="MainLoopCommandExecutionTests.cs" />
     <Compile Include="MainLoopTests.cs" />
+    <Compile Include="PostingCommandFactoryTests.cs" />
+    <Compile Include="PostingCommandTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReadingCommandFactoryTests.cs" />
+    <Compile Include="ReadingCommandTest.cs" />
+    <Compile Include="TimelineRepositoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SocialNetworkTests/TimelineRepositoryTests.cs
+++ b/SocialNetworkTests/TimelineRepositoryTests.cs
@@ -1,0 +1,108 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SocialNetworkCLI.Repositories;
+
+namespace SocialNetworkTests
+{
+    [TestFixture]
+    public class TimelineRepositoryTests
+    {
+        [Test]
+        public void Reading_ShouldReturnEmptyList_OnNewRepository()
+        {
+            // Arrange
+            var repository = new TimelineRepository();
+            var username = "some username";
+
+            // Act
+            var messages = repository.Read(username);
+
+            // Assert
+            Assert.IsNotNull(messages);
+            Assert.AreEqual(0, messages.Count());
+        }
+
+        [Test]
+        public void Should_AcceptEmptyMessage()
+        {
+            // Arrange
+            var repository = new TimelineRepository();
+            var username = "some username";
+            var message = string.Empty;
+            
+            // Act
+            repository.Post(username, message);
+        }
+
+        [Test]
+        public void ShouldNot_AcceptEmptyUsername()
+        {
+            // Arrange
+            var repository = new TimelineRepository();
+            var message = "some username";
+            var username = string.Empty;
+
+            // Act
+            Assert.Throws<ArgumentException>( () => repository.Post(username, message) );
+        }
+
+        [Test]
+        public void Should_BeAbleToRetrieveMessageAfterPosting()
+        {
+            // Arrange
+            var repository = new TimelineRepository();
+            var username = "some username";
+            var messageText = "message";
+
+            // Act
+            repository.Post(username, messageText);
+
+            // Assert
+            var allMessages = repository.Read(username);
+            Assert.AreEqual(1, allMessages.Count());
+            var message = allMessages.First();
+            Assert.AreEqual(messageText, message.Text);
+        }
+
+        [Test]
+        public void Should_AddReasonableTimestampToMessage()
+        {
+            // Arrange
+            var repository = new TimelineRepository();
+            var username = "some username";
+            var messageText = "message";
+            var now = DateTime.Now;
+            // Act
+            repository.Post(username, messageText);
+
+            // Assert
+            var allMessages = repository.Read(username);
+            Assert.AreEqual(1, allMessages.Count());
+            var message = allMessages.First();
+            Assert.GreaterOrEqual(now, message.Timestamp);
+            Assert.LessOrEqual(message.Timestamp, now + TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void Should_NotAllowMessageLeaksBetweenUsers()
+        {
+            // Arrange
+            var repository = new TimelineRepository();
+            var username1 = "some username 1";
+            var username2 = "some username 2";
+            var messageText = "message";
+
+            // Act
+            repository.Post(username1, messageText);
+
+            // Assert
+            var allMessages = repository.Read(username2);
+            Assert.AreEqual(0, allMessages.Count());
+        }
+
+    }
+}

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,11 +1,19 @@
 import subprocess
 import os
 import platform
-from behave import *
+import queue
+import threading
 
 def get_returncode(context):
     context.process.poll()
     return context.process.returncode
+
+def blocking_read(context):
+    try:
+        for line in context.process.stdout:
+            context.stdout_queue.put_nowait(line)
+    except:
+        pass
 
 def before_scenario(context, scenario):
     build_configuration = os.environ.get('BUILD_CONFIGURATION') or os.environ.get('CONFIGURATION') or "Release"
@@ -13,10 +21,22 @@ def before_scenario(context, scenario):
     launchers = {"Windows": (path, []), "Linux": ("mono", path)}
     (launcher, arguments) = launchers[platform.system()]
     context.process = subprocess.Popen(args = [launcher, arguments], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    context.stdout_queue = queue.Queue()
+    context.check_queue = queue.Queue()
+    context.stdout_reading_thread = threading.Thread(name = 'stdout reader', target = blocking_read, args=[context])
+    context.stdout_reading_thread.start()
 
 def after_scenario(context, scenario):
     if get_returncode(context) == None:
         exit_text = "quit%s" % os.linesep
         (output,_) = context.process.communicate(bytearray(exit_text, 'utf-8'), timeout = 5)
+        context.stdout_queue.put_nowait(output)
     if get_returncode(context) == None:
         context.process.kill()
+    whole_output = ""
+    while not context.stdout_queue.empty():
+        output_piece = context.stdout_queue.get()
+        whole_output += str(output_piece)
+    while not context.check_queue.empty():
+        text_to_check = context.check_queue.get()
+        assert text_to_check in whole_output

--- a/features/reading.feature
+++ b/features/reading.feature
@@ -1,0 +1,9 @@
+Feature: Viewing user's timeline
+
+    Anyone should be able to view any user's timeline of messages.
+	Timeline is an aggregate of all messages posted by the user, sorted by time of posting.
+
+    Scenario: Reading the only message posted
+        When I type "Alice -> I love the weather today"
+		And I type "Alice"
+		Then I should see "I love the weather today (just now)"

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -11,7 +11,7 @@ def step_impl(context, text):
 def step_impl(context):
     return_code = get_returncode(context)
     assert return_code == None
-
+	
 @when(u'I wait for 1 second')
 def step_impl(context):
     time.sleep(1)

--- a/features/steps/posting_steps.py
+++ b/features/steps/posting_steps.py
@@ -1,4 +1,3 @@
 @given(u'I\'ve already posted as Alice')
 def step_impl(context):
     context.execute_steps(u"""When I type "Alice -> Some previous text by Alice" """)
-

--- a/features/steps/reading_steps.py
+++ b/features/steps/reading_steps.py
@@ -1,0 +1,18 @@
+import time
+from behave import *
+
+@then(u'I should see "{text}"')
+def step_impl(context, text):
+    output = check_process_output(context)
+    if output:
+        assert text in output
+    else:
+        context.check_queue.put(text)
+
+def check_process_output(context):
+    if context.stdout_queue.empty():
+        return None
+    output = context.stdout_queue.get()
+    return output
+
+


### PR DESCRIPTION
Anyone can view particular user's messages by typing in their user name
now. The messages are sorted in reverse chronological order and
displayed with rough notion of relative time that has passes since the
message has been written.

Coding-wise - all of this is a particularly big change, as this was a first 'real' feature to
implement. There is most of the internal infrastructure being added in
this commit.

General architecture goes as follows:

There is MainLoop. Per each line of the user input it asks
CommandExtractor to create a new command corresponding to that line.
It then executes the command and outputs any result to the output
stream.

Messages posted are now stored in-memory, in TimelineRepository.
PostingCommand adds messages there while ReadingCommand reads from
there.
